### PR TITLE
Remove escaping from ampersand

### DIFF
--- a/MNRAS_abbreviations.txt
+++ b/MNRAS_abbreviations.txt
@@ -1,10 +1,10 @@
 Acta Astronomica = Acta Astron.
-Annual Review of Astronomy and Astrophysics = ARA\&A
+Annual Review of Astronomy and Astrophysics = ARA&A
 Astronomische Nachrichten = Astron. Nachrichten
-Astronomy and Astrophysics = A\&A
-Astrophysics and Space Science = Ap\&SS
+Astronomy and Astrophysics = A&A
+Astrophysics and Space Science = Ap&SS
 GRB Coordinates Network = NASA-GCN
-Journal of Cosmology and Astro-Particle Physics = J. Cosmology \& Astro-Part. Phys.
+Journal of Cosmology and Astro-Particle Physics = J. Cosmology & Astro-Part. Phys.
 Monthly Notices of the Royal Astronomical Society = MNRAS
 Nature = Nat
 New Astronomy Review = New Astron. Rev.


### PR DESCRIPTION
JabRef finally supports abbreviations unesacped (see https://github.com/JabRef/jabref/pull/9288). This leads to more "cleaner" abbreviation lists.

The repository of the abbreviations now checks that lists do not have any ampersands (https://github.com/JabRef/abbrv.jabref.org/pull/108). Therefore, I would like to ask if they could be removed here, too.